### PR TITLE
Migrate to AST media types v2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    apiary_blueprint_convertor (0.1.1)
+    apiary_blueprint_convertor (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![logo](https://raw.github.com/apiaryio/api-blueprint/gh-pages/assets/logo_apiblueprint.png) 
 
 # Apiary Blueprint AST Convertor [![Build Status](https://travis-ci.org/apiaryio/apiary_blueprint_convertor.png?branch=master)](https://travis-ci.org/apiaryio/apiary_blueprint_convertor)
-A migration tool for legacy [Apiary Blueprint](https://github.com/apiaryio/blueprint-parser) AST into [API Blueprint](http://apiblueprint.org) AST. Converts Apiary Blueprint AST serialized into a JSON file to [API Blueprint AST](![logo](https://raw.github.com/apiaryio/api-blueprint/gh-pages/assets/logo_apiblueprint.png) JSON representation (`vnd.apiblueprint.ast.raw+json; version=1.0`).
+A migration tool for legacy [Apiary Blueprint](https://github.com/apiaryio/blueprint-parser) AST into [API Blueprint](http://apiblueprint.org) AST. Converts Apiary Blueprint AST serialized into a JSON file to [API Blueprint AST](https://github.com/apiaryio/api-blueprint-ast) JSON representation (`vnd.apiblueprint.ast.raw+json; version=2.0`).
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/features/convert.feature
+++ b/features/convert.feature
@@ -113,12 +113,13 @@ Feature: Convert AST
     Given a file named "apiblueprint_ast.json" with:
     """
     {
-      "_version": "1.0",
-      "metadata": {
-        "HOST": {
+      "_version": "2.0",
+      "metadata": [
+        {
+          "name": "HOST",
           "value": "http://www.google.com/"
         }
-      },
+      ],
       "name": "Sample API v2",
       "description": "Welcome to our sample API documentation. All comments can be written in (support [Markdown](http://daringfireball.net/projects/markdown/syntax) syntax)",
       "resourceGroups": [
@@ -132,14 +133,12 @@ Feature: Convert AST
               "uriTemplate": "/shopping-cart",
               "model": null,
               "parameters": null,
-              "headers": null,
               "actions": [
                 {
                   "name": null,
                   "description": "List products added into your shopping-cart. (comment block again in Markdown)",
                   "method": "GET",
                   "parameters": null,
-                  "headers": null,
                   "examples": [
                     {
                       "name": null,
@@ -149,11 +148,12 @@ Feature: Convert AST
                         {
                           "name": "200",
                           "description": null,
-                          "headers": {
-                            "Content-Type": {
+                          "headers": [
+                            {
+                              "name": "Content-Type",
                               "value": "application/json"
                             }
-                          },
+                          ],
                           "body": "{\n    \"items\": [\n        {\n            \"url\": \"/shopping-cart/1\",\n            \"product\": \"2ZY48XPZ\",\n            \"quantity\": 1,\n            \"name\": \"New socks\",\n            \"price\": 1.25\n        }\n    ]\n}",
                           "schema": null
                         }
@@ -166,7 +166,6 @@ Feature: Convert AST
                   "description": "Save new products in your shopping cart",
                   "method": "POST",
                   "parameters": null,
-                  "headers": null,
                   "examples": [
                     {
                       "name": null,
@@ -175,11 +174,12 @@ Feature: Convert AST
                         {
                           "name": null,
                           "description": null,
-                          "headers": {
-                            "Content-Type": {
+                          "headers": [
+                            {
+                              "name": "Content-Type",
                               "value": "application/json"
                             }
-                          },
+                          ],
                           "body": "{\n    \"product\": \"1AB23ORM\",\n    \"quantity\": 2\n}",
                           "schema": null
                         }
@@ -188,22 +188,24 @@ Feature: Convert AST
                         {
                           "name": "201",
                           "description": null,
-                          "headers": {
-                            "Content-Type": {
+                          "headers": [
+                            {
+                              "name": "Content-Type",
                               "value": "application/json"
                             }
-                          },
+                          ],
                           "body": "{\n    \"status\": \"created\",\n    \"url\": \"/shopping-cart/2\"\n}",
                           "schema": null
                         },
                         {
                           "name": "401",
                           "description": null,
-                          "headers": {
-                            "Content-Type": {
+                          "headers": [
+                            {
+                              "name": "Content-Type",
                               "value": "application/json; charset=utf-8"
                             }
-                          },
+                          ],
                           "body": "{\n    \"message\": \"You have not provided proper request token\"\n}",
                           "schema": null
                         }
@@ -225,14 +227,12 @@ Feature: Convert AST
               "uriTemplate": "/payment",
               "model": null,
               "parameters": null,
-              "headers": null,
               "actions": [
                 {
                   "name": null,
                   "description": "This resource allows you to submit payment information to process your *shopping cart* items",
                   "method": "POST",
                   "parameters": null,
-                  "headers": null,
                   "examples": [
                     {
                       "name": null,
@@ -266,14 +266,12 @@ Feature: Convert AST
               "uriTemplate": "/resource",
               "model": null,
               "parameters": null,
-              "headers": null,
               "actions": [
                 {
                   "name": null,
                   "description": null,
                   "method": "POST",
                   "parameters": null,
-                  "headers": null,
                   "examples": [
                     {
                       "name": null,
@@ -282,11 +280,12 @@ Feature: Convert AST
                         {
                           "name": null,
                           "description": null,
-                          "headers": {
-                            "Content-Type": {
+                          "headers": [
+                            {
+                              "name": "Content-Type",
                               "value": "application/json"
                             }
-                          },
+                          ],
                           "body": "{\n    \"a\": \"b\",\n    \"c\": \"0\"\n}",
                           "schema": "{\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\",\"format\":\"alphanumeric\"},\"c\":{\"type\":\"integer\"}}}"
                         }

--- a/lib/apiary_blueprint_convertor/convertor.rb
+++ b/lib/apiary_blueprint_convertor/convertor.rb
@@ -5,7 +5,7 @@ module ApiaryBlueprintConvertor
   
   class Convertor
 
-    API_BLUEPRONT_AST_VERSION = "1.0"
+    API_BLUEPRINT_AST_VERSION = "2.0"
 
     def self.read_file(file)
       unless File.readable?(file)
@@ -33,7 +33,7 @@ module ApiaryBlueprintConvertor
       
       # Top level API Blueprint Template
       blueprint_ast = {
-        :_version => API_BLUEPRONT_AST_VERSION,
+        :_version => API_BLUEPRINT_AST_VERSION,
         :metadata => nil,
         :name => nil,
         :description => nil,
@@ -77,11 +77,12 @@ module ApiaryBlueprintConvertor
         return
       end
 
-      blueprint_ast[:metadata] = {
-        :HOST => {
+      blueprint_ast[:metadata] = [
+        {
+          :name => "HOST",
           :value => "#{legacy_location}"
         }
-      }
+      ]
     end
 
     # Convert array of blueprint sections
@@ -125,7 +126,6 @@ module ApiaryBlueprintConvertor
             :uriTemplate => legacy_resource[:url],
             :model => nil,
             :parameters => nil,
-            :headers => nil,
             :actions => nil
           }
           
@@ -162,7 +162,6 @@ module ApiaryBlueprintConvertor
         :description => legacy_resource[:description],
         :method => legacy_resource[:method],
         :parameters => nil,
-        :headers => nil,
         :examples => nil
       }
 
@@ -234,12 +233,15 @@ module ApiaryBlueprintConvertor
     # from legacy headers hash
     def self.create_headers_hash(legacy_headers)
       return nil if legacy_headers.blank?
-      headers = {}
+      headers = []
 
       legacy_headers.each do |key, value|
-        headers[key] = {
-          :value => value
+        header = {
+          :name => key.to_s,
+          :value => value.to_s
         }
+
+        headers << header
       end
 
       headers

--- a/lib/apiary_blueprint_convertor/version.rb
+++ b/lib/apiary_blueprint_convertor/version.rb
@@ -1,3 +1,3 @@
 module ApiaryBlueprintConvertor
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/test/convertor_test.rb
+++ b/test/convertor_test.rb
@@ -88,13 +88,9 @@ class ConvertorTest < Minitest::Test
     assert_equal 1, blueprint_ast.keys.length
     assert_equal :metadata, blueprint_ast.keys.first
 
-    assert_equal 1, blueprint_ast[:metadata].keys.length
-    assert_equal :HOST, blueprint_ast[:metadata].keys.first
-
-    assert_equal 1, blueprint_ast[:metadata][:HOST].keys.length
-    assert_equal :value, blueprint_ast[:metadata][:HOST].keys.first
-
-    assert_equal "http://google.com", blueprint_ast[:metadata][:HOST][:value]
+    assert_equal 1, blueprint_ast[:metadata].length
+    assert_equal "HOST", blueprint_ast[:metadata][0][:name]
+    assert_equal "http://google.com", blueprint_ast[:metadata][0][:value]
   end
 
   def test_convert_blueprint
@@ -104,6 +100,7 @@ class ConvertorTest < Minitest::Test
     assert_equal 4, blueprint_ast.keys.length
 
     assert blueprint_ast[:metadata]
+    assert_equal 1, blueprint_ast[:metadata].length
     assert_equal "API NAME", blueprint_ast[:name]
     assert_equal "Lorem Ipsum", blueprint_ast[:description]
     assert blueprint_ast[:resourceGroups]
@@ -145,7 +142,6 @@ class ConvertorTest < Minitest::Test
     assert_equal "/resource1", group_ast[:resources][0][:uriTemplate]
     assert_equal nil, group_ast[:resources][0][:model]
     assert_equal nil, group_ast[:resources][0][:parameters]
-    assert_equal nil, group_ast[:resources][0][:headers]
     assert group_ast[:resources][0][:actions]
     assert_equal 2, group_ast[:resources][0][:actions].length
 
@@ -154,7 +150,6 @@ class ConvertorTest < Minitest::Test
     assert_equal "/resource2", group_ast[:resources][1][:uriTemplate]
     assert_equal nil, group_ast[:resources][1][:model]
     assert_equal nil, group_ast[:resources][1][:parameters]
-    assert_equal nil, group_ast[:resources][1][:headers]
     assert group_ast[:resources][1][:actions]
     assert_equal 1, group_ast[:resources][1][:actions].length
   end
@@ -168,7 +163,6 @@ class ConvertorTest < Minitest::Test
     assert_equal "GET", resource_ast[:actions][0][:method]
     assert_equal "Ipsum Lorem", resource_ast[:actions][0][:description]
     assert_equal nil, resource_ast[:actions][0][:parameters]
-    assert_equal nil, resource_ast[:actions][0][:headers]
     assert_instance_of Array, resource_ast[:actions][0][:examples]
   end
 
@@ -195,34 +189,23 @@ class ConvertorTest < Minitest::Test
     assert_equal "200", action_ast[:examples][0][:responses][0][:name]
     assert_equal nil, action_ast[:examples][0][:responses][0][:description]
     
-    assert_instance_of Hash, action_ast[:examples][0][:responses][0][:headers]
-    assert_equal 1, action_ast[:examples][0][:responses][0][:headers].keys.length
-    assert_equal :'Content-Type', action_ast[:examples][0][:responses][0][:headers].keys[0]
-    assert_instance_of Hash, action_ast[:examples][0][:responses][0][:headers][:'Content-Type']
-    assert_equal 1, action_ast[:examples][0][:responses][0][:headers][:'Content-Type'].keys.length
-    assert_equal :value, action_ast[:examples][0][:responses][0][:headers][:'Content-Type'].keys[0]
-    assert_equal "text/plain", action_ast[:examples][0][:responses][0][:headers][:'Content-Type'][:value]
-
+    assert_instance_of Array, action_ast[:examples][0][:responses][0][:headers]
+    assert_equal 1, action_ast[:examples][0][:responses][0][:headers].length
+    assert_equal "Content-Type", action_ast[:examples][0][:responses][0][:headers][0][:name]
+    assert_equal "text/plain", action_ast[:examples][0][:responses][0][:headers][0][:value]
     assert_equal "Hello World!", action_ast[:examples][0][:responses][0][:body]
     assert_equal "0xdeadbeef", action_ast[:examples][0][:responses][0][:schema]
 
     assert_equal "404", action_ast[:examples][0][:responses][1][:name]
     assert_equal nil, action_ast[:examples][0][:responses][1][:description]
 
-    assert_instance_of Hash, action_ast[:examples][0][:responses][1][:headers]
-    assert_equal 2, action_ast[:examples][0][:responses][1][:headers].keys.length
+    assert_instance_of Array, action_ast[:examples][0][:responses][1][:headers]
+    assert_equal 2, action_ast[:examples][0][:responses][1][:headers].length
     
-    assert_equal :'Content-Type', action_ast[:examples][0][:responses][1][:headers].keys[0]
-    assert_instance_of Hash, action_ast[:examples][0][:responses][1][:headers][:'Content-Type']
-    assert_equal 1, action_ast[:examples][0][:responses][1][:headers][:'Content-Type'].keys.length
-    assert_equal :value, action_ast[:examples][0][:responses][1][:headers][:'Content-Type'].keys[0]
-    assert_equal "application/json", action_ast[:examples][0][:responses][1][:headers][:'Content-Type'][:value]
-
-    assert_equal :'X-Header', action_ast[:examples][0][:responses][1][:headers].keys[1]
-    assert_instance_of Hash, action_ast[:examples][0][:responses][1][:headers][:'X-Header']
-    assert_equal 1, action_ast[:examples][0][:responses][1][:headers][:'X-Header'].keys.length
-    assert_equal :value, action_ast[:examples][0][:responses][1][:headers][:'X-Header'].keys[0]
-    assert_equal "42", action_ast[:examples][0][:responses][1][:headers][:'X-Header'][:value]
+    assert_equal "Content-Type", action_ast[:examples][0][:responses][1][:headers][0][:name]
+    assert_equal "application/json", action_ast[:examples][0][:responses][1][:headers][0][:value]
+    assert_equal "X-Header", action_ast[:examples][0][:responses][1][:headers][1][:name]
+    assert_equal "42", action_ast[:examples][0][:responses][1][:headers][1][:value]
 
     assert_equal "42 not found.", action_ast[:examples][0][:responses][1][:body]
     assert_equal "0xdeadbeef", action_ast[:examples][0][:responses][1][:schema]


### PR DESCRIPTION
This is a backward **incompatible** change. Refer to https://github.com/apiaryio/api-blueprint-ast/releases/tag/v2.0 for the list of changes in AST media types v2.0
