### PR TITLE
Add deprecation notice to Apiary Blueprint Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 # Apiary Blueprint AST Convertor [![Build Status](https://travis-ci.org/apiaryio/apiary_blueprint_convertor.png?branch=master)](https://travis-ci.org/apiaryio/apiary_blueprint_convertor)
 A migration tool for legacy [Apiary Blueprint](https://github.com/apiaryio/blueprint-parser) AST into [API Blueprint](http://apiblueprint.org) AST. Converts Apiary Blueprint AST serialized into a JSON file to [API Blueprint AST](https://github.com/apiaryio/api-blueprint-ast) JSON representation (`vnd.apiblueprint.ast.raw+json; version=2.0`).
 
+**NOTE**: *This library is deprecated in favour of
+[fury](https://github.com/apiaryio/fury) and the [Fury API Blueprint
+Serializer](https://github.com/apiaryio/fury-adapter-apib-serializer).*
+
 ## Installation
 Add this line to your application's Gemfile:
 


### PR DESCRIPTION
This library was superseded by Fury a long time ago.